### PR TITLE
Fix testscripts for pre lodged hx

### DIFF
--- a/Import XSDs/Test cases/Test Cases - H1/Test Case - H1 Pre-lodged/Test Case - H1 Pre-lodge_v1.3.xml
+++ b/Import XSDs/Test cases/Test Cases - H1/Test Case - H1 Pre-lodged/Test Case - H1 Pre-lodge_v1.3.xml
@@ -51,7 +51,7 @@
         <ns2:GovernmentAgencyGoodsItem>
             <ns2:SequenceNumeric>1</ns2:SequenceNumeric>
             <ns2:StatisticalValueAmount>5000</ns2:StatisticalValueAmount>
-            <ns2:TransactionNatureCode>1</ns2:TransactionNatureCode>
+            <ns2:TransactionNatureCode>11</ns2:TransactionNatureCode>
             <ns2:Commodity>
                 <ns2:Description>Green (Tapet)</ns2:Description>
                 <ns2:Classification>
@@ -80,7 +80,7 @@
                     <ns2:TariffQuantity>0</ns2:TariffQuantity>
                 </ns2:GoodsMeasure>
                 <ns2:InvoiceLine>
-                    <ns2:ItemChargeAmount currencyID="EUR">7500</ns2:ItemChargeAmount>
+                    <ns2:ItemChargeAmount currencyID="CAD">1000000000000</ns2:ItemChargeAmount>
                 </ns2:InvoiceLine>
             </ns2:Commodity>
             <ns2:CustomsValuation>

--- a/Import XSDs/Test cases/Test Cases - H2/Test Case - H2 Pre-lodged/Test Case - H2 Pre-lodged_v1.2.xml
+++ b/Import XSDs/Test cases/Test Cases - H2/Test Case - H2 Pre-lodged/Test Case - H2 Pre-lodged_v1.2.xml
@@ -90,9 +90,6 @@
                 <ns2:QuantityQuantity>1500</ns2:QuantityQuantity>
                 <ns2:TypeCode>OC</ns2:TypeCode>
             </ns2:Packaging>
-            <ns2:DispatchCountry>
-                <ns2:ID>NO</ns2:ID>
-            </ns2:DispatchCountry>
             <ns2:TransportContractDocument>
                 <ns2:SequenceNumeric>1</ns2:SequenceNumeric>
                 <ns2:ID>DK123123123</ns2:ID>

--- a/Import XSDs/Test cases/Test Cases - H3/Test Case - H3 Pre-lodged/Test Case - H3 Pre-lodged_v1.4.xml
+++ b/Import XSDs/Test cases/Test Cases - H3/Test Case - H3 Pre-lodged/Test Case - H3 Pre-lodged_v1.4.xml
@@ -57,7 +57,7 @@
         <ns2:GovernmentAgencyGoodsItem>
             <ns2:SequenceNumeric>1</ns2:SequenceNumeric>
             <ns2:StatisticalValueAmount>24499</ns2:StatisticalValueAmount>
-            <ns2:TransactionNatureCode>1</ns2:TransactionNatureCode>
+            <ns2:TransactionNatureCode>41</ns2:TransactionNatureCode>
             <ns2:AdditionalInformation>
                 <ns2:SequenceNumeric>1</ns2:SequenceNumeric>
                 <ns2:StatementCode>00400</ns2:StatementCode>
@@ -93,7 +93,7 @@
                     <ns2:TariffQuantity unitCode="NAR">60</ns2:TariffQuantity>
                 </ns2:GoodsMeasure>
                 <ns2:InvoiceLine>
-                    <ns2:ItemChargeAmount>2700</ns2:ItemChargeAmount>
+                    <ns2:ItemChargeAmount currencyID="GBP">18000</ns2:ItemChargeAmount>
                 </ns2:InvoiceLine>
             </ns2:Commodity>
             <ns2:CustomsValuation>
@@ -129,9 +129,6 @@
                 <ns2:ID>1</ns2:ID>
                 <ns2:TypeCode>C605</ns2:TypeCode>
             </ns2:PreviousDocument>
-            <ns2:DispatchCountry>
-                <ns2:ID>DK</ns2:ID>
-            </ns2:DispatchCountry>
             <ns2:SupportingDocument>
                 <ns2:SequenceNumeric>1</ns2:SequenceNumeric>
                 <ns2:ID>123456</ns2:ID>

--- a/Import XSDs/Test cases/Test Cases - H4/Test Case - H4 Pre-lodged/Test Case - H4 Pre-lodged v1.3.xml
+++ b/Import XSDs/Test cases/Test Cases - H4/Test Case - H4 Pre-lodged/Test Case - H4 Pre-lodged v1.3.xml
@@ -45,7 +45,7 @@
         <ns3:GovernmentAgencyGoodsItem>
             <ns3:SequenceNumeric>1</ns3:SequenceNumeric>
             <ns3:StatisticalValueAmount>74429</ns3:StatisticalValueAmount>
-            <ns3:TransactionNatureCode>1</ns3:TransactionNatureCode>
+            <ns3:TransactionNatureCode>11</ns3:TransactionNatureCode>
             <ns3:Commodity>
                 <ns3:Description>Inertial navigation systems</ns3:Description>
                 <ns3:Classification>
@@ -74,7 +74,7 @@
                     <ns3:TariffQuantity unitCode="NAR">200</ns3:TariffQuantity>
                 </ns3:GoodsMeasure>
                 <ns3:InvoiceLine>
-                    <ns3:ItemChargeAmount>455</ns3:ItemChargeAmount>
+                    <ns3:ItemChargeAmount currencyID="DKK">74429</ns3:ItemChargeAmount>
                 </ns3:InvoiceLine>
             </ns3:Commodity>
             <ns3:CustomsValuation>

--- a/Import XSDs/Test cases/Test Cases - H5/Test Case - H5 Pre-lodged/Test Case - H5 Pre-lodged v1.3.xml
+++ b/Import XSDs/Test cases/Test Cases - H5/Test Case - H5 Pre-lodged/Test Case - H5 Pre-lodged v1.3.xml
@@ -50,7 +50,7 @@
         <ns2:GovernmentAgencyGoodsItem>
             <ns2:SequenceNumeric>1</ns2:SequenceNumeric>
             <ns2:StatisticalValueAmount>5000</ns2:StatisticalValueAmount>
-            <ns2:TransactionNatureCode>1</ns2:TransactionNatureCode>
+            <ns2:TransactionNatureCode>11</ns2:TransactionNatureCode>
             <ns2:Commodity>
                 <ns2:Description>Dried Fruits</ns2:Description>
                 <ns2:Classification>
@@ -77,7 +77,7 @@
                     <ns2:NetNetWeightMeasure>100</ns2:NetNetWeightMeasure>
                 </ns2:GoodsMeasure>
                 <ns2:InvoiceLine>
-                    <ns2:ItemChargeAmount>1000</ns2:ItemChargeAmount>
+                    <ns2:ItemChargeAmount currencyID="EUR">1000</ns2:ItemChargeAmount>
                 </ns2:InvoiceLine>
             </ns2:Commodity>
             <ns2:CustomsValuation>
@@ -103,6 +103,11 @@
                 <ns2:QuantityQuantity>10</ns2:QuantityQuantity>
                 <ns2:TypeCode>BX</ns2:TypeCode>
             </ns2:Packaging>
+            <ns2:SupportingDocument>
+                <ns2:SequenceNumeric>1</ns2:SequenceNumeric>
+                <ns2:ID>EJ OMFATTET</ns2:ID>
+                <ns2:TypeCode>Y929</ns2:TypeCode>
+            </ns2:SupportingDocument>
         </ns2:GovernmentAgencyGoodsItem>
         <ns2:Importer>
             <ns2:ID>{{ImporterEORI}}</ns2:ID>
@@ -110,6 +115,7 @@
         <ns2:TradeTerms>
             <ns2:ConditionCode>FCA</ns2:ConditionCode>
             <ns2:LocationName>INCOTERM</ns2:LocationName>
+            <ns2:CountryCode>FR</ns2:CountryCode>
         </ns2:TradeTerms>
         <ns2:DispatchCountry>
             <ns2:ID>FR</ns2:ID>

--- a/Import XSDs/Test cases/Test Cases - I1/Test Case - I1 Pre-Lodged/Test Case - I1 Pre-lodged_v1.2.xml
+++ b/Import XSDs/Test cases/Test Cases - I1/Test Case - I1 Pre-Lodged/Test Case - I1 Pre-lodged_v1.2.xml
@@ -100,6 +100,11 @@
                 <ns2:ID>1234567</ns2:ID>
                 <ns2:TypeCode>Y824</ns2:TypeCode>
             </ns2:AdditionalReference>
+            <ns2:AdditionalReference>
+                <ns2:SequenceNumeric>2</ns2:SequenceNumeric>
+                <ns2:ID>EJ OMFATTET</ns2:ID>
+                <ns2:TypeCode>Y237</ns2:TypeCode>
+            </ns2:AdditionalReference>
             <ns2:TransportContractDocument>
                 <ns2:SequenceNumeric>1</ns2:SequenceNumeric>
                 <ns2:ID>123-1234567</ns2:ID>


### PR DESCRIPTION
### 2026-05-26
* Update testcase scripts for Pre-lodged Import H1-H5
  * TransactionNatureCode set to either 11 or 41
  * ItemChargeAmount set to match InvoiceAmount
  * DispatchCountry removed from GIL
  * SupportingDocument Y929 added to GIL (H5)
  * CountryCode FR added to TradeTerms (H5)