### PR TITLE
Fix testscripts for correction hx

### DIFF
--- a/Import XSDs/Test cases/Test Cases - H1/Test Case - H1 Correction/Test Case - H1 Correction_v1.3.xml
+++ b/Import XSDs/Test cases/Test Cases - H1/Test Case - H1 Correction/Test Case - H1 Correction_v1.3.xml
@@ -57,7 +57,7 @@
         <ns2:GovernmentAgencyGoodsItem>
             <ns2:SequenceNumeric>1</ns2:SequenceNumeric>
             <ns2:StatisticalValueAmount>2500</ns2:StatisticalValueAmount>
-            <ns2:TransactionNatureCode>1</ns2:TransactionNatureCode>
+            <ns2:TransactionNatureCode>11</ns2:TransactionNatureCode>
             <ns2:Commodity>
                 <ns2:Description>Green (Tapet)</ns2:Description>
                 <ns2:Classification>
@@ -86,7 +86,7 @@
                     <ns2:TariffQuantity>0</ns2:TariffQuantity>
                 </ns2:GoodsMeasure>
                 <ns2:InvoiceLine>
-                    <ns2:ItemChargeAmount currencyID="EUR">7500</ns2:ItemChargeAmount>
+                    <ns2:ItemChargeAmount currencyID="CAD">1000000000000</ns2:ItemChargeAmount>
                 </ns2:InvoiceLine>
             </ns2:Commodity>
             <ns2:CustomsValuation>

--- a/Import XSDs/Test cases/Test Cases - H2/Test Case - H2 Correction/Test Case - H2 Correction_v1.2.xml
+++ b/Import XSDs/Test cases/Test Cases - H2/Test Case - H2 Correction/Test Case - H2 Correction_v1.2.xml
@@ -91,9 +91,6 @@
                 <ns2:QuantityQuantity>1500</ns2:QuantityQuantity>
                 <ns2:TypeCode>OC</ns2:TypeCode>
             </ns2:Packaging>
-            <ns2:DispatchCountry>
-                <ns2:ID>NO</ns2:ID>
-            </ns2:DispatchCountry>
             <ns2:TransportContractDocument>
                 <ns2:SequenceNumeric>1</ns2:SequenceNumeric>
                 <ns2:ID>DK123123123</ns2:ID>

--- a/Import XSDs/Test cases/Test Cases - H3/Test Case - H3 Correction/Test Case - H3 Correction v_1.4.xml
+++ b/Import XSDs/Test cases/Test Cases - H3/Test Case - H3 Correction/Test Case - H3 Correction v_1.4.xml
@@ -64,7 +64,7 @@
         <ns2:GovernmentAgencyGoodsItem>
             <ns2:SequenceNumeric>1</ns2:SequenceNumeric>
             <ns2:StatisticalValueAmount>24499</ns2:StatisticalValueAmount>
-            <ns2:TransactionNatureCode>1</ns2:TransactionNatureCode>
+            <ns2:TransactionNatureCode>41</ns2:TransactionNatureCode>
             <ns2:AdditionalInformation>
                 <ns2:SequenceNumeric>1</ns2:SequenceNumeric>
                 <ns2:StatementCode>00400</ns2:StatementCode>
@@ -100,7 +100,7 @@
                     <ns2:TariffQuantity unitCode="NAR">60</ns2:TariffQuantity>
                 </ns2:GoodsMeasure>
                 <ns2:InvoiceLine>
-                    <ns2:ItemChargeAmount>2700</ns2:ItemChargeAmount>
+                    <ns2:ItemChargeAmount currencyID="GBP">18000</ns2:ItemChargeAmount>
                 </ns2:InvoiceLine>
             </ns2:Commodity>
             <ns2:CustomsValuation>
@@ -136,9 +136,6 @@
                 <ns2:ID>1</ns2:ID>
                 <ns2:TypeCode>C605</ns2:TypeCode>
             </ns2:PreviousDocument>
-            <ns2:DispatchCountry>
-                <ns2:ID>DK</ns2:ID>
-            </ns2:DispatchCountry>
             <ns2:SupportingDocument>
                 <ns2:SequenceNumeric>1</ns2:SequenceNumeric>
                 <ns2:ID>123456</ns2:ID>

--- a/Import XSDs/Test cases/Test Cases - H4/Test Case - H4 Correction/Test Case - H4 Correction v.1.3.xml
+++ b/Import XSDs/Test cases/Test Cases - H4/Test Case - H4 Correction/Test Case - H4 Correction v.1.3.xml
@@ -51,7 +51,7 @@
         <ns2:GovernmentAgencyGoodsItem>
             <ns2:SequenceNumeric>1</ns2:SequenceNumeric>
             <ns2:StatisticalValueAmount>74429</ns2:StatisticalValueAmount>
-            <ns2:TransactionNatureCode>1</ns2:TransactionNatureCode>
+            <ns2:TransactionNatureCode>11</ns2:TransactionNatureCode>
             <ns2:Commodity>
                 <ns2:Description>Inertial navigation systems</ns2:Description>
                 <ns2:Classification>
@@ -80,7 +80,7 @@
                     <ns2:TariffQuantity unitCode="NAR">200</ns2:TariffQuantity>
                 </ns2:GoodsMeasure>
                 <ns2:InvoiceLine>
-                    <ns2:ItemChargeAmount>455</ns2:ItemChargeAmount>
+                    <ns2:ItemChargeAmount currencyID="DKK">74429</ns2:ItemChargeAmount>
                 </ns2:InvoiceLine>
             </ns2:Commodity>
             <ns2:CustomsValuation>

--- a/Import XSDs/Test cases/Test Cases - H5/Test Case - H5 Correction/Test Case - H5 Correction_v1.3.xml
+++ b/Import XSDs/Test cases/Test Cases - H5/Test Case - H5 Correction/Test Case - H5 Correction_v1.3.xml
@@ -57,7 +57,7 @@
         <ns2:GovernmentAgencyGoodsItem>
             <ns2:SequenceNumeric>1</ns2:SequenceNumeric>
             <ns2:StatisticalValueAmount>5000</ns2:StatisticalValueAmount>
-            <ns2:TransactionNatureCode>1</ns2:TransactionNatureCode>
+            <ns2:TransactionNatureCode>11</ns2:TransactionNatureCode>
             <ns2:Commodity>
                 <ns2:Description>Dried Fruits</ns2:Description>
                 <ns2:Classification>
@@ -84,7 +84,7 @@
                     <ns2:NetNetWeightMeasure>100</ns2:NetNetWeightMeasure>
                 </ns2:GoodsMeasure>
                 <ns2:InvoiceLine>
-                    <ns2:ItemChargeAmount>1000</ns2:ItemChargeAmount>
+                    <ns2:ItemChargeAmount currencyID="EUR">15682.29</ns2:ItemChargeAmount>
                 </ns2:InvoiceLine>
             </ns2:Commodity>
             <ns2:CustomsValuation>
@@ -110,6 +110,11 @@
                 <ns2:QuantityQuantity>10</ns2:QuantityQuantity>
                 <ns2:TypeCode>BX</ns2:TypeCode>
             </ns2:Packaging>
+            <ns2:SupportingDocument>
+                <ns2:SequenceNumeric>1</ns2:SequenceNumeric>
+                <ns2:ID>EJ OMFATTET</ns2:ID>
+                <ns2:TypeCode>Y929</ns2:TypeCode>
+            </ns2:SupportingDocument>
         </ns2:GovernmentAgencyGoodsItem>
         <ns2:Importer>
             <ns2:ID>{{ImporterEORI}}</ns2:ID>
@@ -117,6 +122,7 @@
         <ns2:TradeTerms>
             <ns2:ConditionCode>FCA</ns2:ConditionCode>
             <ns2:LocationName>INCOTERM</ns2:LocationName>
+            <ns2:CountryCode>FR</ns2:CountryCode>
         </ns2:TradeTerms>
         <ns2:DispatchCountry>
             <ns2:ID>FR</ns2:ID>


### PR DESCRIPTION
### 2026-05-26
* Update testcase scripts for Correction Import H1-H5
  * TransactionNatureCode set to either 11 or 41
  * ItemChargeAmount set to match InvoiceAmount
  * DispatchCountry removed from GIL
  * SupportingDocument Y929 added to GIL (H5)
  * CountryCode FR added to TradeTerms (H5)