### PR TITLE
Fix testscripts for 4 c invalidation

### DIFF
--- a/Import XSDs/Test cases/Test Cases - H1/Test Case - H1 Invalidation and Repayment/Test Case - H1 Invalidation and Repayment 4c_v1.4.xml
+++ b/Import XSDs/Test cases/Test Cases - H1/Test Case - H1 Invalidation and Repayment/Test Case - H1 Invalidation and Repayment 4c_v1.4.xml
@@ -24,6 +24,19 @@
             <ns1:TelephoneNumber>12345678</ns1:TelephoneNumber>
             <ns1:EmailAddress>em@told.dk</ns1:EmailAddress>
         </ns1:ApplicationSupervisor>
+        <ns1:GoodsLocation>
+            <ns1:IdentificationQualifier>V</ns1:IdentificationQualifier>
+            <ns1:CustomsOffice>DK003102</ns1:CustomsOffice>
+        </ns1:GoodsLocation>
+        <ns1:TraderCommodityCode>
+            <ns1:HarmonisedSystemSubheadingCode>080430</ns1:HarmonisedSystemSubheadingCode>
+            <ns1:NomenclatureCode>00</ns1:NomenclatureCode>
+            <ns1:TaricSubheading>90</ns1:TaricSubheading>
+        </ns1:TraderCommodityCode>
+        <ns1:TraderGoodsQuantity>
+            <ns1:Measurement>KG</ns1:Measurement>
+            <ns1:Quantity>15000</ns1:Quantity>
+        </ns1:TraderGoodsQuantity>
         <!-- Amount from CWMTAX notification -->
         <ns1:AmountDuty>
             <ns1:Currency>DKK</ns1:Currency>

--- a/Import XSDs/Test cases/Test Cases - H2/Test Case - H2 Invalidation and Repayment/Test Case - H2 Invalidation and Repayment 4c_v1.3.xml
+++ b/Import XSDs/Test cases/Test Cases - H2/Test Case - H2 Invalidation and Repayment/Test Case - H2 Invalidation and Repayment 4c_v1.3.xml
@@ -24,6 +24,19 @@
             <ns1:TelephoneNumber>12345678</ns1:TelephoneNumber>
             <ns1:EmailAddress>em@told.dk</ns1:EmailAddress>
         </ns1:ApplicationSupervisor>
+        <ns1:GoodsLocation>
+            <ns1:IdentificationQualifier>V</ns1:IdentificationQualifier>
+            <ns1:CustomsOffice>DK003102</ns1:CustomsOffice>
+        </ns1:GoodsLocation>
+        <ns1:TraderCommodityCode>
+            <ns1:HarmonisedSystemSubheadingCode>080430</ns1:HarmonisedSystemSubheadingCode>
+            <ns1:NomenclatureCode>00</ns1:NomenclatureCode>
+            <ns1:TaricSubheading>90</ns1:TaricSubheading>
+        </ns1:TraderCommodityCode>
+        <ns1:TraderGoodsQuantity>
+            <ns1:Measurement>KG</ns1:Measurement>
+            <ns1:Quantity>15000</ns1:Quantity>
+        </ns1:TraderGoodsQuantity>
         <!-- Amount from CWMTAX notification -->
         <ns1:AmountDuty>
             <ns1:Currency>DKK</ns1:Currency>

--- a/Import XSDs/Test cases/Test Cases - H5/Test Case - H5 Invalidation and Repayment/Test Case - H5 Invalidation and Repayment 4c_v1.2.xml
+++ b/Import XSDs/Test cases/Test Cases - H5/Test Case - H5 Invalidation and Repayment/Test Case - H5 Invalidation and Repayment 4c_v1.2.xml
@@ -11,7 +11,7 @@
     </ns2:Submitter>
     <ns2:Amendment>
         <ns2:SequenceNumeric>1</ns2:SequenceNumeric>
-        <ns2:ChangeReasonCode>22</ns2:ChangeReasonCode>
+        <ns2:ChangeReasonCode>122</ns2:ChangeReasonCode>
 		<ns2:ChangeReasonText>Changed by Submitter</ns2:ChangeReasonText>
     </ns2:Amendment>
     <ns2:RepaymentRemissionAuthorisation>
@@ -23,7 +23,19 @@
             <ns1:TelephoneNumber>12345678</ns1:TelephoneNumber>
             <ns1:EmailAddress>em@told.dk</ns1:EmailAddress>
         </ns1:ApplicationSupervisor>
-		<ns1:RecoveryTitle>placeholdermrn</ns1:RecoveryTitle>
+        <ns1:GoodsLocation>
+            <ns1:IdentificationQualifier>V</ns1:IdentificationQualifier>
+            <ns1:CustomsOffice>DK003102</ns1:CustomsOffice>
+        </ns1:GoodsLocation>
+        <ns1:TraderCommodityCode>
+            <ns1:HarmonisedSystemSubheadingCode>080430</ns1:HarmonisedSystemSubheadingCode>
+            <ns1:NomenclatureCode>00</ns1:NomenclatureCode>
+            <ns1:TaricSubheading>90</ns1:TaricSubheading>
+        </ns1:TraderCommodityCode>
+        <ns1:TraderGoodsQuantity>
+            <ns1:Measurement>KG</ns1:Measurement>
+            <ns1:Quantity>15000</ns1:Quantity>
+        </ns1:TraderGoodsQuantity>
 		<ns1:CustomsValue>
 			<ns1:Currency>DKK</ns1:Currency>
 			<ns1:Amount>123</ns1:Amount>
@@ -35,7 +47,6 @@
         </ns1:AmountDuty>
         <ns1:DutyType>
             <ns1:UnionCode>B00</ns1:UnionCode>
-            <ns1:NationalCode>1DK</ns1:NationalCode>
         </ns1:DutyType>
         <ns1:LegalBasis>E</ns1:LegalBasis>
     </ns2:RepaymentRemissionAuthorisation>

--- a/Import XSDs/Test cases/Test Cases - H6/Test Case - H6 Invalidation and Repayment/Test Case - H6 Invalidation and Repayment 4c_v1.1.xml
+++ b/Import XSDs/Test cases/Test Cases - H6/Test Case - H6 Invalidation and Repayment/Test Case - H6 Invalidation and Repayment 4c_v1.1.xml
@@ -25,6 +25,19 @@
             <ns1:FaxNumber>12345678</ns1:FaxNumber>
             <ns1:EmailAddress>em@told.dk</ns1:EmailAddress>
         </ns1:ApplicationSupervisor>
+        <ns1:GoodsLocation>
+            <ns1:IdentificationQualifier>V</ns1:IdentificationQualifier>
+            <ns1:CustomsOffice>DK003102</ns1:CustomsOffice>
+        </ns1:GoodsLocation>
+        <ns1:TraderCommodityCode>
+            <ns1:HarmonisedSystemSubheadingCode>080430</ns1:HarmonisedSystemSubheadingCode>
+            <ns1:NomenclatureCode>00</ns1:NomenclatureCode>
+            <ns1:TaricSubheading>90</ns1:TaricSubheading>
+        </ns1:TraderCommodityCode>
+        <ns1:TraderGoodsQuantity>
+            <ns1:Measurement>KG</ns1:Measurement>
+            <ns1:Quantity>15000</ns1:Quantity>
+        </ns1:TraderGoodsQuantity>
         <ns1:AmountDuty>
             <ns1:Currency>DKK</ns1:Currency>
             <ns1:Amount>1</ns1:Amount>

--- a/Import XSDs/Test cases/Test Cases - H7/Test Case - H7 Invalidation and Repayment (4c)/Test Case - H7 Invalidation and Repayment 4c_v2.3.xml
+++ b/Import XSDs/Test cases/Test Cases - H7/Test Case - H7 Invalidation and Repayment (4c)/Test Case - H7 Invalidation and Repayment 4c_v2.3.xml
@@ -13,7 +13,7 @@
     </ns2:Submitter>
     <ns2:Amendment>
         <ns2:SequenceNumeric>1</ns2:SequenceNumeric>
-        <ns2:ChangeReasonCode>22</ns2:ChangeReasonCode>
+        <ns2:ChangeReasonCode>122</ns2:ChangeReasonCode>
 		<ns2:ChangeReasonText>Corrected by declarant</ns2:ChangeReasonText>
     </ns2:Amendment>
     <ns2:RepaymentRemissionAuthorisation>
@@ -26,6 +26,19 @@
             <ns1:FaxNumber>12345678</ns1:FaxNumber>
             <ns1:EmailAddress>em@told.dk</ns1:EmailAddress>
         </ns1:ApplicationSupervisor>
+        <ns1:GoodsLocation>
+            <ns1:IdentificationQualifier>V</ns1:IdentificationQualifier>
+            <ns1:CustomsOffice>DK003102</ns1:CustomsOffice>
+        </ns1:GoodsLocation>
+        <ns1:TraderCommodityCode>
+            <ns1:HarmonisedSystemSubheadingCode>080430</ns1:HarmonisedSystemSubheadingCode>
+            <ns1:NomenclatureCode>00</ns1:NomenclatureCode>
+            <ns1:TaricSubheading>90</ns1:TaricSubheading>
+        </ns1:TraderCommodityCode>
+        <ns1:TraderGoodsQuantity>
+            <ns1:Measurement>KG</ns1:Measurement>
+            <ns1:Quantity>15000</ns1:Quantity>
+        </ns1:TraderGoodsQuantity>
         <ns1:AmountDuty>
             <ns1:Currency>DKK</ns1:Currency>
             <ns1:Amount>275.0</ns1:Amount>

--- a/Import XSDs/Test cases/Test Cases - I1/Test Case - I1 Invalidation and Repayment/Test Case - I1 Invalidation and Repayment 4c_v1.1.xml
+++ b/Import XSDs/Test cases/Test Cases - I1/Test Case - I1 Invalidation and Repayment/Test Case - I1 Invalidation and Repayment 4c_v1.1.xml
@@ -25,6 +25,19 @@
             <ns1:FaxNumber>12345678</ns1:FaxNumber>
             <ns1:EmailAddress>em@told.dk</ns1:EmailAddress>
         </ns1:ApplicationSupervisor>
+        <ns1:GoodsLocation>
+            <ns1:IdentificationQualifier>V</ns1:IdentificationQualifier>
+            <ns1:CustomsOffice>DK003102</ns1:CustomsOffice>
+        </ns1:GoodsLocation>
+        <ns1:TraderCommodityCode>
+            <ns1:HarmonisedSystemSubheadingCode>080430</ns1:HarmonisedSystemSubheadingCode>
+            <ns1:NomenclatureCode>00</ns1:NomenclatureCode>
+            <ns1:TaricSubheading>90</ns1:TaricSubheading>
+        </ns1:TraderCommodityCode>
+        <ns1:TraderGoodsQuantity>
+            <ns1:Measurement>KG</ns1:Measurement>
+            <ns1:Quantity>15000</ns1:Quantity>
+        </ns1:TraderGoodsQuantity>
         <ns1:AmountDuty>
             <ns1:Currency>DKK</ns1:Currency>
             <ns1:Amount>1</ns1:Amount>

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,12 @@
+### 2026-06-18
+* Update testcase scripts for Invalidation and Repayment (4C)
+  * ChangeReasonCode set to 122
+  * GoodsLocation added with customs office DK003102
+  * TraderCommodityCode added with hssc 080430
+  * TraderGoodsQuantity added with 15.000 kg
+  * RecoveryTitle removed from 4C auth
+  * NationalCode removed from DutyType
+
 ### 2026-06-16
 * Add DMS - Customs duty on low value consignments.pdf
 * Update Test Case - H4 Standard.pdf


### PR DESCRIPTION
### 2026-06-18
* Update testcase scripts for Invalidation and Repayment (4C)
  * ChangeReasonCode set to 122
  * GoodsLocation added with customs office DK003102
  * TraderCommodityCode added with hssc 080430
  * TraderGoodsQuantity added with 15.000 kg
  * RecoveryTitle removed from 4C auth
  * NationalCode removed from DutyType