### PR TITLE
Fix testscripts for export ccl/ctl/vic

### DIFF
--- a/Export XSDs/Test cases/Test Case - Centralized Clearance/Test Case - B1 Centralized Clearance_v1.3.xml
+++ b/Export XSDs/Test cases/Test Case - Centralized Clearance/Test Case - B1 Centralized Clearance_v1.3.xml
@@ -12,7 +12,7 @@
     </ns3:Submitter>
     <ns3:Authorisation>
         <ns3:SequenceNumeric>1</ns3:SequenceNumeric>
-        <ns3:ID>DKCCL80-123456</ns3:ID>
+        <ns3:ID>{{CCLAuthorisation}}</ns3:ID>
         <ns3:Type>C513</ns3:Type>
     </ns3:Authorisation>
     <ns3:Declarant>
@@ -41,7 +41,7 @@
     <ns3:GoodsShipment>
         <ns3:Consignment>
             <ns3:BorderTransportMeans>
-                <ns3:ID>RegistrationNumber</ns3:ID>
+                <ns3:ID>FLIGHT1337</ns3:ID>
                 <ns3:IdentificationTypeCode>30</ns3:IdentificationTypeCode>
                 <ns3:RegistrationNationalityCode>DK</ns3:RegistrationNationalityCode>
                 <ns3:ModeCode>3</ns3:ModeCode>
@@ -76,6 +76,7 @@
         <ns3:GovernmentAgencyGoodsItem>
             <ns3:SequenceNumeric>1</ns3:SequenceNumeric>
             <ns3:StatisticalValueAmount>100.00</ns3:StatisticalValueAmount>
+            <ns3:TransactionNatureCode>1</ns3:TransactionNatureCode>
             <ns3:Commodity>
                 <ns3:Description>Heifers of the grey, brown or yellow mountain breeds and spotted Pinzgau breed, other than for slaughter; Of a weight not exceeding 80 kg</ns3:Description>
                 <ns3:Classification>

--- a/Export XSDs/Test cases/Test Case - Control/Test Case - B1 document control_v1.1.xml
+++ b/Export XSDs/Test cases/Test Case - Control/Test Case - B1 document control_v1.1.xml
@@ -31,7 +31,7 @@
         </ns3:Consignee>
         <ns3:Consignment>
             <ns3:BorderTransportMeans>
-                <ns3:ID>RegistrationNumber</ns3:ID>
+                <ns3:ID>FLIGHT1337</ns3:ID>
                 <ns3:IdentificationTypeCode>30</ns3:IdentificationTypeCode>
                 <ns3:RegistrationNationalityCode>DK</ns3:RegistrationNationalityCode>
                 <ns3:ModeCode>3</ns3:ModeCode>
@@ -57,6 +57,7 @@
         <ns3:GovernmentAgencyGoodsItem>
             <ns3:SequenceNumeric>1</ns3:SequenceNumeric>
             <ns3:StatisticalValueAmount>7442</ns3:StatisticalValueAmount>
+            <ns3:TransactionNatureCode>1</ns3:TransactionNatureCode>
             <ns3:Commodity>
                 <ns3:Description>control document aeo</ns3:Description>
                 <ns3:Classification>
@@ -98,7 +99,7 @@
                 <ns3:SequenceNumeric>1</ns3:SequenceNumeric>
                 <ns3:CategoryCode>N</ns3:CategoryCode>
                 <ns3:ID>ID123</ns3:ID>
-                <ns3:TypeCode>380</ns3:TypeCode>
+                <ns3:TypeCode>N380</ns3:TypeCode>
             </ns3:PreviousDocument>
             <ns3:UCR>
                 <ns3:TraderAssignedReferenceID>P198R65Q29</ns3:TraderAssignedReferenceID>

--- a/Export XSDs/Test cases/Test Case - Control/Test Case - B1 physical control_v1.1.xml
+++ b/Export XSDs/Test cases/Test Case - Control/Test Case - B1 physical control_v1.1.xml
@@ -31,7 +31,7 @@
         </ns3:Consignee>
         <ns3:Consignment>
             <ns3:BorderTransportMeans>
-                <ns3:ID>RegistrationNumber</ns3:ID>
+                <ns3:ID>FLIGHT1337</ns3:ID>
                 <ns3:IdentificationTypeCode>30</ns3:IdentificationTypeCode>
                 <ns3:RegistrationNationalityCode>DK</ns3:RegistrationNationalityCode>
                 <ns3:ModeCode>3</ns3:ModeCode>
@@ -57,6 +57,7 @@
         <ns3:GovernmentAgencyGoodsItem>
             <ns3:SequenceNumeric>1</ns3:SequenceNumeric>
             <ns3:StatisticalValueAmount>7442</ns3:StatisticalValueAmount>
+            <ns3:TransactionNatureCode>1</ns3:TransactionNatureCode>
             <ns3:Commodity>
                 <ns3:Description>control aeo</ns3:Description>
                 <ns3:Classification>
@@ -98,7 +99,7 @@
                 <ns3:SequenceNumeric>1</ns3:SequenceNumeric>
                 <ns3:CategoryCode>N</ns3:CategoryCode>
                 <ns3:ID>ID123</ns3:ID>
-                <ns3:TypeCode>380</ns3:TypeCode>
+                <ns3:TypeCode>N380</ns3:TypeCode>
             </ns3:PreviousDocument>
             <ns3:UCR>
                 <ns3:TraderAssignedReferenceID>P198R65Q29</ns3:TraderAssignedReferenceID>

--- a/Export XSDs/Test cases/Test Case - Victualling/Test Case - Victualling (proviant) B1_v1.1.xml
+++ b/Export XSDs/Test cases/Test Case - Victualling/Test Case - Victualling (proviant) B1_v1.1.xml
@@ -147,6 +147,7 @@
         <ns3:GovernmentAgencyGoodsItem>
             <ns3:SequenceNumeric>1</ns3:SequenceNumeric>
             <ns3:StatisticalValueAmount>10000</ns3:StatisticalValueAmount>
+            <ns3:TransactionNatureCode>52</ns3:TransactionNatureCode>
             <ns3:Commodity>
                 <ns3:Description>Goods delivered to vessels and aircraft</ns3:Description>
                 <ns3:Classification>

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,14 @@
 ### 2026-06-29
+* Update testcase scripts for Export Centralized Clerance
+  * Authorisation set to {{CCLAuthorisation}}
+  * BorderTransportMeansID set to FLIGHT1337
+  * TransactionNatureCode added with value 1
+* Update testcase scripts for Export Control
+  * BorderTransportMeansID set to FLIGHT1337
+  * TransactionNatureCode added with value 1
+  * PreviousDocumentType set to N380
+* Update testcase scripts for Export Victualling
+  * TransactionNatureCode added with value 52
 * Update of DMS Onboardingguide to version 2.3
   * H7 description updated for low value consignments
 


### PR DESCRIPTION
### 2026-06-29
* Update testcase scripts for Export Centralized Clerance
  * Authorisation set to {{CCLAuthorisation}}
  * BorderTransportMeansID set to FLIGHT1337
  * TransactionNatureCode added with value 1
* Update testcase scripts for Export Control
  * BorderTransportMeansID set to FLIGHT1337
  * TransactionNatureCode added with value 1
  * PreviousDocumentType set to N380
* Update testcase scripts for Export Victualling
  * TransactionNatureCode added with value 52